### PR TITLE
feat: add typography

### DIFF
--- a/app/contacto/page.tsx
+++ b/app/contacto/page.tsx
@@ -45,7 +45,7 @@ export default function ContactoPage() {
     }
 
     return (
-        <main className="max-w-6xl mx-auto px-4 py-12">
+    <main className="max-w-6xl mx-auto px-4 py-12 font-bricolage">
             <div className="flex flex-col md:flex-row items-start gap-8">
                 <div className="flex flex-col w-full md:w-2/3">
                     <div className="px-4 sm:px-6 lg:px-8">
@@ -59,7 +59,7 @@ export default function ContactoPage() {
                             {t('descripcion')}
                         </p>
                         <div className="bg-white rounded-lg p-8 w-full max-w-md shadow flex flex-col gap-4 mb-20 md:mb-30">
-                            <div className="font-poppins flex flex-col gap-4">
+                            <div className="flex flex-col gap-4">
                                 <form onSubmit={handleSubmit} className="flex flex-col gap-4">
                                     <label className="font-medium text-[#1F1B3B]" htmlFor="nombre">{t('nombre')}</label>
                                     <input

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,10 +1,15 @@
 @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:wght@400;600;700;800&display=swap');
+@import "tailwindcss";
+
+.font-bricolage {
+  font-family: 'Bricolage Grotesque', 'Poppins', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+}
 
 .font-poppins {
   font-family: 'Poppins', sans-serif;
 }
-
-@import "tailwindcss";
 
 :root {
   --background: #F2F2F2;
@@ -21,7 +26,7 @@
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+  font-family: 'Bricolage Grotesque', 'Poppins', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
     "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -41,15 +46,15 @@ body {
 
 
 h1 {
-  font-family: 'Poppins', sans-serif;
-  font-weight: 500;
+  font-family: 'Bricolage Grotesque', sans-serif;
+  font-weight: 600;
   color: #1F1B3B;
   line-height: 124.5%;
   letter-spacing: 0;
 }
 
 p {
-  font-family: 'Poppins', sans-serif;
+  font-family: 'Bricolage Grotesque', sans-serif;
   font-weight: 400;
   color: #1F1B3B;
   line-height: 140%;
@@ -57,7 +62,7 @@ p {
 }
 
 h2 {
-  font-family: 'Poppins', sans-serif;
+  font-family: 'Bricolage Grotesque', sans-serif;
   font-weight: 400;
   color: #1F1B3B;
   line-height: 140%;
@@ -65,7 +70,7 @@ h2 {
 }
 
 h3 {
-  font-family: 'Poppins', sans-serif;
+  font-family: 'Bricolage Grotesque', sans-serif;
   font-weight: 400;
   color: #F2F2F2;
   line-height: 140%;
@@ -74,14 +79,14 @@ h3 {
 
 
 h4 {
-  font-family: 'Poppins', sans-serif;
+  font-family: 'Bricolage Grotesque', sans-serif;
   color: #2451D7;
   line-height: 140%;
   letter-spacing: 0;
 }
 
 h5 {
-  font-family: 'Poppins', sans-serif;
+  font-family: 'Bricolage Grotesque', sans-serif;
   font-weight: 800;
   color: #1F1B3B;
   line-height: 124.5%;

--- a/app/nosotros/page.tsx
+++ b/app/nosotros/page.tsx
@@ -27,7 +27,7 @@ export default function NosotrosPage() {
                 </h1>
                 <div className="flex flex-col md:flex-row items-center gap-8 mb-20 px-4 sm:px-6 lg:px-8 relative  md:translate-x-20" style={{ minHeight: '260px' }}>
                     <div className="w-full md:w-1/2 flex justify-center md:justify-end z-20 ">
-                        <p className="bg-white rounded-lg shadow-lg p-6 text-[#1F1B3B] text-base sm:text-xl font-poppins max-w-md" style={{ boxShadow: '4px 4px 6px #B3B3B3' }}>
+                        <p className="bg-white rounded-lg shadow-lg p-6 text-[#1F1B3B] text-base sm:text-xl font-bricolage max-w-md" style={{ boxShadow: '4px 4px 6px #B3B3B3' }}>
                             {t('intro')}
                         </p>
                     </div>
@@ -40,7 +40,7 @@ export default function NosotrosPage() {
             </main>
             <section className="relative bg-[#52B2EB] py-20 py-40">
                 <div className="max-w-6xl mx-auto flex flex-col md:flex-row items-center md:items-stretch justify-center md:justify-center gap-20 px-4">
-                    <div className="bg-white rounded-lg shadow-lg p-8 flex flex-col min-h-[350px] w-full md:w-1/3 max-w-2xs flex-1 font-poppins transition-transform duration-300 hover:-translate-y-2" style={{ boxShadow: '4px 4px 6px #B3B3B3' }} >
+                    <div className="bg-white rounded-lg shadow-lg p-8 flex flex-col min-h-[350px] w-full md:w-1/3 max-w-2xs flex-1 font-bricolage transition-transform duration-300 hover:-translate-y-2" style={{ boxShadow: '4px 4px 6px #B3B3B3' }} >
                         <div className="flex flex-col items-center w-full mb-2">
                             <svg className="w-12 h-12 mb-4 text-[#2451D7]" fill="none" stroke="currentColor" viewBox="0 0 48 48">
                                 <circle cx="24" cy="24" r="20" strokeWidth="2" />
@@ -50,7 +50,7 @@ export default function NosotrosPage() {
                         </div>
                         <p className="text-[#1F1B3B] text-base text-left">{t('mision.descripcion')}</p>
                     </div>
-                    <div className="bg-white rounded-lg shadow-lg p-8 flex flex-col min-h-[350px] w-full md:w-1/3 max-w-2xs flex-1 font-poppins transition-transform duration-300 hover:-translate-y-2" style={{ boxShadow: '4px 4px 6px #B3B3B3' }} >
+                    <div className="bg-white rounded-lg shadow-lg p-8 flex flex-col min-h-[350px] w-full md:w-1/3 max-w-2xs flex-1 font-bricolage transition-transform duration-300 hover:-translate-y-2" style={{ boxShadow: '4px 4px 6px #B3B3B3' }} >
                         <div className="flex flex-col items-center w-full mb-2">
                             <svg className="w-12 h-12 mb-4 text-[#2451D7]" fill="none" stroke="currentColor" viewBox="0 0 48 48">
                                 <ellipse cx="24" cy="24" rx="16" ry="10" strokeWidth="2" />
@@ -61,7 +61,7 @@ export default function NosotrosPage() {
                         </div>
                         <p className="text-[#1F1B3B] text-base text-left">{t('vision.descripcion')}</p>
                     </div>
-                    <div className="bg-white rounded-lg shadow-lg p-8 flex flex-col min-h-[350px] w-full md:w-1/3 max-w-2xs flex-1 font-poppins transition-transform duration-300 hover:-translate-y-2" style={{ boxShadow: '4px 4px 6px #B3B3B3' }} >
+                    <div className="bg-white rounded-lg shadow-lg p-8 flex flex-col min-h-[350px] w-full md:w-1/3 max-w-2xs flex-1 font-bricolage transition-transform duration-300 hover:-translate-y-2" style={{ boxShadow: '4px 4px 6px #B3B3B3' }} >
                         <div className="flex flex-col items-center w-full mb-2">
                             <svg className="w-12 h-12 mb-4 text-[#2451D7]" fill="none" stroke="currentColor" viewBox="0 0 48 48">
                                 <path d="M24 8v32M16 24h16" strokeWidth="2" />
@@ -132,7 +132,7 @@ export default function NosotrosPage() {
                 </p>
                 <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-6 px-4 sm:px-6 lg:px-8">
                     {Object.values(t('politicas', { returnObjects: true })).slice(0, 3).map((pol: string, i: number) => (
-                        <div key={i} className="bg-[#E5E5E5] rounded-lg flex items-center gap-4 px-6 py-5 font-poppins shadow cursor-pointer transition-transform duration-300 hover:-translate-y-2">
+                        <div key={i} className="bg-[#E5E5E5] rounded-lg flex items-center gap-4 px-6 py-5 font-bricolage shadow cursor-pointer transition-transform duration-300 hover:-translate-y-2">
                             <svg className="w-8 h-8 text-[#1F1B3B]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <rect x="3" y="3" width="18" height="18" rx="2" strokeWidth="2" />
                                 <path d="M7 7h10M7 11h10M7 15h6" strokeWidth="2" />
@@ -143,7 +143,7 @@ export default function NosotrosPage() {
                 </div>
                 <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-20 px-4 sm:px-6 lg:px-8">
                     {Object.values(t('politicas', { returnObjects: true })).slice(3).map((pol: string, i: number) => (
-                        <div key={i} className="bg-[#E5E5E5] rounded-lg flex items-center gap-4 px-6 py-5 font-poppins shadow cursor-pointer transition-transform duration-300 hover:-translate-y-2">
+                        <div key={i} className="bg-[#E5E5E5] rounded-lg flex items-center gap-4 px-6 py-5 font-bricolage shadow cursor-pointer transition-transform duration-300 hover:-translate-y-2">
                             <svg className="w-8 h-8 text-[#1F1B3B]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <rect x="3" y="3" width="18" height="18" rx="2" strokeWidth="2" />
                                 <path d="M7 7h10M7 11h10M7 15h6" strokeWidth="2" />

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -14,7 +14,7 @@ const Footer = () => {
                     <div className="mb-1">
                         <Image src="/img/ciclo-white.png" alt="Ciclo Logo" width={140} height={45} />
                     </div>
-                    <h3 className="font-poppins font-normal text-base md:text-sm lg:text-sm mb-8 text-[#F2F2F2] max-w-xs md:max-w-sm lg:max-w-md text-left break-words">{t('footer.descripcion')}</h3>
+                    <h3 className="font-bricolage font-normal text-base md:text-sm lg:text-sm mb-8 text-[#F2F2F2] max-w-xs md:max-w-sm lg:max-w-md text-left break-words">{t('footer.descripcion')}</h3>
                     <div className="flex gap-4 text-2xl text-[#4F5BFF]">
                         {/* ...iconos... */}
                         <a href="#" aria-label="YouTube"><svg className="h-6 w-6" fill="currentColor" viewBox="0 0 24 24"><path d="M23.498 6.186a2.994 2.994 0 0 0-2.108-2.115C19.073 3.5 12 3.5 12 3.5s-7.073 0-9.39.571A2.994 2.994 0 0 0 .502 6.186C0 8.504 0 12 0 12s0 3.496.502 5.814a2.994 2.994 0 0 0 2.108 2.115C4.927 20.5 12 20.5 12 20.5s7.073 0 9.39-.571a2.994 2.994 0 0 0 2.108-2.115C24 15.496 24 12 24 12s0-3.496-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z" /></svg></a>
@@ -24,24 +24,24 @@ const Footer = () => {
                     </div>
                 </div>
                 <div className="min-w-[120px]">
-                    <h3 className="font-poppins font-medium text-lg md:text-xl lg:text-2xl mb-6">{t('footer.servicios')}</h3>
-                    <ul className="font-poppins font-normal text-sm md:text-sm lg:text-sm space-y-4 text-[#F2F2F2]">
+                    <h3 className="font-bricolage font-medium text-lg md:text-xl lg:text-2xl mb-6">{t('footer.servicios')}</h3>
+                    <ul className="font-bricolage font-normal text-sm md:text-sm lg:text-sm space-y-4 text-[#F2F2F2]">
                         <li className="text-base md:text-sm lg:text-sm">{t('footer.servicios_gestion')}</li>
                         <li className="text-base md:text-sm lg:text-sm">{t('footer.servicios_reciclaje')}</li>
                         <li className="text-base md:text-sm lg:text-sm">{t('footer.servicios_valorizacion')}</li>
                     </ul>
                 </div>
                 <div className="min-w-[120px]">
-                    <h3 className="font-poppins font-medium text-lg md:text-xl lg:text-2xl mb-6">{t('footer.productos')}</h3>
-                    <ul className="font-poppins font-normal text-sm md:text-sm lg:text-sm space-y-4 text-[#F2F2F2]">
+                    <h3 className="font-bricolage font-medium text-lg md:text-xl lg:text-2xl mb-6">{t('footer.productos')}</h3>
+                    <ul className="font-bricolage font-normal text-sm md:text-sm lg:text-sm space-y-4 text-[#F2F2F2]">
                         <li className="text-base md:text-sm lg:text-sm">{t('footer.productos_ecoadoquines')}</li>
                         <li className="text-base md:text-sm lg:text-sm">{t('footer.productos_bloques')}</li>
                         <li className="text-base md:text-sm lg:text-sm">{t('footer.productos_agregados')}</li>
                     </ul>
                 </div>
                 <div className="min-w-[150px]">
-                    <h3 className="font-poppins font-medium text-lg md:text-xl lg:text-2xl mb-6">{t('footer.contacto')}</h3>
-                    <ul className="font-poppins font-normal text-sm md:text-sm lg:text-sm space-y-4 text-[#F2F2F2]">
+                    <h3 className="font-bricolage font-medium text-lg md:text-xl lg:text-2xl mb-6">{t('footer.contacto')}</h3>
+                    <ul className="font-bricolage font-normal text-sm md:text-sm lg:text-sm space-y-4 text-[#F2F2F2]">
                         <li className="text-base md:text-sm lg:text-sm">
                             {t('footer.direccion').split('\n').map((line, i, arr) => (
                                 <React.Fragment key={i}>
@@ -57,8 +57,8 @@ const Footer = () => {
             </div>
             <div className="border-t border-[#C9A86A] my-6"></div>
             <div className="flex flex-col md:flex-row justify-between text-base md:text-sm lg:text-sm items-center text-[#F2F2F2]/80 w-full">
-                <span className="w-full md:w-auto text-left truncate font-poppins font-medium text-base md:text-sm lg:text-sm">{t('footer.copyright')}</span>
-                <a href="#" className="font-poppins font-medium text-base md:text-sm lg:text-sm text-[#2451D7] hover:underline mt-2 md:mt-0">{t('footer.terminos')}</a>
+                <span className="w-full md:w-auto text-left truncate font-bricolage font-medium text-base md:text-sm lg:text-sm">{t('footer.copyright')}</span>
+                <a href="#" className="font-bricolage font-medium text-base md:text-sm lg:text-sm text-[#2451D7] hover:underline mt-2 md:mt-0">{t('footer.terminos')}</a>
             </div>
         </footer>
     );


### PR DESCRIPTION
This pull request updates the site's typography to use the new `Bricolage Grotesque` font as the primary typeface instead of `Poppins`, improving consistency and visual identity across all pages and components. The changes affect both global styles and specific components, including the main content, footer, and various sections in the `Nosotros` and `Contacto` pages.

**Typography and font updates:**

* Added import for `Bricolage Grotesque` in `app/globals.css`, created a `.font-bricolage` class, and updated the default `body` font-family to prioritize `Bricolage Grotesque`. [[1]](diffhunk://#diff-79e0914d9fee5ca4432bdb002a24d700d31b5577265f4de3f90d5c292b9f1392R2-L8) [[2]](diffhunk://#diff-79e0914d9fee5ca4432bdb002a24d700d31b5577265f4de3f90d5c292b9f1392L24-R29)
* Updated all heading (`h1`–`h5`) and paragraph (`p`) styles in `app/globals.css` to use `Bricolage Grotesque` instead of `Poppins`, with adjusted font weights for headings. [[1]](diffhunk://#diff-79e0914d9fee5ca4432bdb002a24d700d31b5577265f4de3f90d5c292b9f1392L44-R73) [[2]](diffhunk://#diff-79e0914d9fee5ca4432bdb002a24d700d31b5577265f4de3f90d5c292b9f1392L77-R89)

**Component and page styling:**

* Replaced `font-poppins` with `font-bricolage` in all major sections of the `Nosotros` page, including mission, vision, and policy cards. [[1]](diffhunk://#diff-0d1628e4c73a3aa9f1d9e5dd4fc6747b2ced0690f47b5712711ea147f0653a19L30-R30) [[2]](diffhunk://#diff-0d1628e4c73a3aa9f1d9e5dd4fc6747b2ced0690f47b5712711ea147f0653a19L43-R43) [[3]](diffhunk://#diff-0d1628e4c73a3aa9f1d9e5dd4fc6747b2ced0690f47b5712711ea147f0653a19L53-R53) [[4]](diffhunk://#diff-0d1628e4c73a3aa9f1d9e5dd4fc6747b2ced0690f47b5712711ea147f0653a19L64-R64) [[5]](diffhunk://#diff-0d1628e4c73a3aa9f1d9e5dd4fc6747b2ced0690f47b5712711ea147f0653a19L135-R135) [[6]](diffhunk://#diff-0d1628e4c73a3aa9f1d9e5dd4fc6747b2ced0690f47b5712711ea147f0653a19L146-R146)
* Updated the `Contacto` page to use `font-bricolage` for the main content and removed unnecessary `font-poppins` usage from form containers. [[1]](diffhunk://#diff-ee363d5144e83d8f7184075ae313c44a37494a239ed6afd91667ebffd510914aL48-R48) [[2]](diffhunk://#diff-ee363d5144e83d8f7184075ae313c44a37494a239ed6afd91667ebffd510914aL62-R62)
* Switched all typography in the `Footer` component to use `font-bricolage` for headings, lists, and copyright/links. [[1]](diffhunk://#diff-4f34a078049f572f5ebcdf8a3b771ce47c64ec9808cf3acf95a04e1ab72c214dL17-R17) [[2]](diffhunk://#diff-4f34a078049f572f5ebcdf8a3b771ce47c64ec9808cf3acf95a04e1ab72c214dL27-R44) [[3]](diffhunk://#diff-4f34a078049f572f5ebcdf8a3b771ce47c64ec9808cf3acf95a04e1ab72c214dL60-R61)