### PR TITLE
Feat/reponsive home

### DIFF
--- a/app/inicio/page.tsx
+++ b/app/inicio/page.tsx
@@ -1,4 +1,4 @@
-"use client"
+"use client";
 
 import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -16,7 +16,7 @@ export default function Home() {
 
   React.useEffect(() => {
     const interval = setInterval(() => {
-      setAngle(a => (a + 1) % 360);
+      setAngle((a) => (a + 1) % 360);
     }, 16);
     return () => clearInterval(interval);
   }, []);
@@ -27,111 +27,146 @@ export default function Home() {
       const observer = new MutationObserver(() => {
         setIsDark(document.documentElement.classList.contains("dark"));
       });
-      observer.observe(document.documentElement, { attributes: true, attributeFilter: ["class"] });
+      observer.observe(document.documentElement, {
+        attributes: true,
+        attributeFilter: ["class"],
+      });
       return () => observer.disconnect();
     }
   }, []);
 
   const cards = [
     {
-      titulo: t('servicios.card1_titulo'),
+      titulo: t("servicios.card1_titulo"),
       img: "/img/Group.svg",
-      desc: t('servicios.card1_desc')
+      desc: t("servicios.card1_desc"),
     },
     {
-      titulo: t('servicios.card2_titulo'),
+      titulo: t("servicios.card2_titulo"),
       img: "/img/Vector.svg",
-      desc: t('servicios.card2_desc')
-    }
+      desc: t("servicios.card2_desc"),
+    },
   ];
 
   return (
     <>
       <Hero />
-      <section className="relative min-h-[500px] sm:min-h-[600px] md:min-h-[700px] lg:min-h-[800px] mt-20">
+      <section className="relative min-h-[300px] sm:min-h-[400px] md:min-h-[500px] lg:min-h-[600px] xl:min-h-[700px] mt-12 sm:mt-16 lg:mt-20">
         <div className="absolute inset-0 w-full h-full">
           <Image
             src="/pages/servicios/5-Servicios.webp"
             alt="Fondo sección"
             fill
-            style={{ objectFit: 'cover', zIndex: 0 }}
+            style={{ objectFit: "cover", zIndex: 0 }}
             priority
           />
         </div>
       </section>
-      <section className="w-full flex flex-col py-14">
-        <div className="w-full max-w-6xl mx-auto">
-          <h2 className="text-2xl sm:text-3xl lg:text-4xl font-semibold mb-10 text-[#1F1B3B] text-left">{t('circularidad_titulo')}</h2>
+      <section className="w-full flex flex-col py-8 sm:py-12 lg:py-16 overflow-hidden">
+        <div className="w-full max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+          <h2 className="text-2xl sm:text-3xl lg:text-4xl font-semibold mb-8 sm:mb-12 lg:mb-16 text-[#1F1B3B] text-center sm:text-left">
+            {t("circularidad_titulo")}
+          </h2>
           <div className="flex justify-center w-full">
             <div
-              className="relative flex justify-center items-center"
-              style={{
-                width: 400,
-                height: 800,
-                transform: "rotate(45deg)",
-                transformOrigin: "200px 400px",
-              }}
+              className="relative w-full max-w-lg overflow-hidden flex justify-center items-center"
+              style={{ minHeight: "500px" }}
             >
-              <svg
-                width="400"
-                height="800"
-                viewBox="0 0 400 800"
-                className="block absolute top-0 left-0"
-                style={{ zIndex: 2 }}
+              <div
+                className="relative flex justify-center items-center"
+                style={{
+                  width: "min(350px, 80vw)",
+                  height: "min(700px, 160vw)",
+                  transform: "rotate(45deg)",
+                  transformOrigin: "center center",
+                }}
               >
-                <ellipse cx="200" cy="400" rx="180" ry="380" fill="none" stroke='var(--primary-border)' strokeWidth="3" />
-              </svg>
-              {(() => {
-                const cx = 200, cy = 400, rx = 180, ry = 380;
-                const rad = (angle * Math.PI) / 180;
-                const x = cx + rx * Math.cos(rad);
-                const y = cy + ry * Math.sin(rad);
-                return (
-                  <div
-                    style={{
-                      position: 'absolute',
-                      left: `${x - 10}px`,
-                      top: `${y - 10}px`,
-                      width: 20,
-                      height: 20,
-                      background: 'var(--primary-border)',
-                      borderRadius: '50%',
-                      zIndex: 10,
-                      transition: 'left 0.1s linear, top 0.1s linear',
-                    }}
+                <svg
+                  width="100%"
+                  height="100%"
+                  viewBox="0 0 350 700"
+                  className="absolute top-0 left-0"
+                  style={{ zIndex: 2 }}
+                  preserveAspectRatio="xMidYMid meet"
+                >
+                  <ellipse
+                    cx="175"
+                    cy="350"
+                    rx="140"
+                    ry="320"
+                    fill="none"
+                    stroke="var(--primary-border)"
+                    strokeWidth="3"
                   />
-                );
-              })()}
-              <div
-                className="absolute"
-                style={{
-                  top: '450px',
-                  left: '-250px',
-                  zIndex: 2,
-                  transform: "rotate(-45deg)"
-                }}
-              >
-                <Image src="/pages/inicio/residuos.png" alt={t('circularidad_residuos_alt')} width={200} height={60} />
-              </div>
-              <div
-                className="absolute"
-                style={{
-                  bottom: '450px',
-                  right: '-250px',
-                  zIndex: 2,
-                  transform: "rotate(-45deg)"
-                }}
-              >
-                <Image
-                  src={isDark ? "/pages/inicio/materiales-white.png" : "/pages/inicio/materiales.png"}
-                  alt={t('circularidad_materiales_alt')}
-                  width={200}
-                  height={60}
-                />              </div>
-              <div className="absolute top-0 left-0 w-full h-full flex items-center justify-center" style={{ transform: "rotate(-45deg)" }}>
-                <div style={{ display: "flex", justifyContent: "center", alignItems: "center", width: "100%", height: "100%" }}>
-                  <p className="text-[#1F1B3B] text-left text-base md:text-lg font-medium max-w-[300px]">
-                    {t('circularidad_texto')}
+                </svg>
+                {(() => {
+                  const cx = 175,
+                    cy = 350,
+                    rx = 140,
+                    ry = 320;
+                  const rad = (angle * Math.PI) / 180;
+                  const x = cx + rx * Math.cos(rad);
+                  const y = cy + ry * Math.sin(rad);
+                  return (
+                    <div
+                      style={{
+                        position: "absolute",
+                        left: `${x - 8}px`,
+                        top: `${y - 8}px`,
+                        width: 16,
+                        height: 16,
+                        background: "var(--primary-border)",
+                        borderRadius: "50%",
+                        zIndex: 10,
+                        transition: "left 0.1s linear, top 0.1s linear",
+                      }}
+                    />
+                  );
+                })()}
+                <div
+                  className="absolute"
+                  style={{
+                    top: "56%",
+                    left: "-50%",
+                    zIndex: 2,
+                    transform: "rotate(-45deg)",
+                  }}
+                >
+                  <Image
+                    src="/pages/inicio/residuos.png"
+                    alt={t("circularidad_residuos_alt")}
+                    width={140}
+                    height={42}
+                    className="w-[100px] sm:w-[120px] md:w-[140px] h-auto"
+                  />
+                </div>
+                <div
+                  className="absolute"
+                  style={{
+                    bottom: "56%",
+                    right: "-50%",
+                    zIndex: 2,
+                    transform: "rotate(-45deg)",
+                  }}
+                >
+                  <Image
+                    src={
+                      isDark
+                        ? "/pages/inicio/materiales-white.png"
+                        : "/pages/inicio/materiales.png"
+                    }
+                    alt={t("circularidad_materiales_alt")}
+                    width={140}
+                    height={42}
+                    className="w-[100px] sm:w-[120px] md:w-[140px] h-auto"
+                  />
+                </div>
+                <div
+                  className="absolute inset-0 flex items-center justify-center"
+                  style={{ transform: "rotate(-45deg)" }}
+                >
+                  <p className="text-[#1F1B3B] text-center text-sm sm:text-base md:text-lg font-medium max-w-[180px] sm:max-w-[220px] md:max-w-[260px] px-3 leading-tight">
+                    {t("circularidad_texto")}
                   </p>
                 </div>
               </div>
@@ -139,163 +174,237 @@ export default function Home() {
           </div>
         </div>
       </section>
-      <section className="w-full flex flex-col items-center py-16 ">
-        <h2 className="text-2xl sm:text-3xl lg:text-4xl font-semibold mb-20 text-[#1F1B3B]">{t('servicios_titulo')}</h2>
-        <div className="w-full max-w-6xl flex items-center justify-center relative h-[400px]">
-          <div className="relative w-full h-[400px] flex items-center justify-center">
+      <section className="w-full flex flex-col items-center py-12 sm:py-16 lg:py-20">
+        <h2 className="text-2xl sm:text-3xl lg:text-4xl font-semibold mb-12 sm:mb-16 lg:mb-20 text-[#1F1B3B] text-center px-4">
+          {t("servicios_titulo")}
+        </h2>
+        <div className="w-full max-w-6xl flex items-center justify-center relative min-h-[350px] sm:min-h-[400px] px-4">
+          <div className="relative w-full min-h-[350px] sm:min-h-[400px] flex items-center justify-center">
             {cards.map((card, i) => {
               const pos = (i - activeIndex + cards.length) % cards.length;
               const zIndex = 10 - pos;
-              const scale = 1 - pos * 0.08;
-              const translateX = pos * 100;
+              const scale = 1 - pos * 0.05;
+              const translateX = pos * 60;
               const opacity = pos === 0 ? 1 : 0.8 - pos * 0.2;
               return (
                 <div
                   key={i}
-                  className={
-                    `absolute left-1/2 -translate-x-1/2 bg-white rounded-lg shadow-lg p-8 flex flex-col min-h-[350px] w-full md:w-3/5 max-w-3xl font-poppins transition-all duration-500 cursor-pointer ${pos === 0 ? '' : 'hover:scale-105'}`
-                  }
+                  className={`absolute left-1/2 -translate-x-1/2 bg-white rounded-lg shadow-lg p-6 sm:p-8 flex flex-col min-h-[300px] sm:min-h-[350px] w-[90%] sm:w-4/5 md:w-3/5 max-w-2xl font-poppins transition-all duration-500 cursor-pointer ${
+                    pos === 0 ? "" : "hover:scale-105"
+                  }`}
                   style={{
                     zIndex,
                     transform: `scale(${scale}) translateX(${translateX}px)`,
-                    opacity
+                    opacity,
                   }}
                   aria-label={card.titulo}
                   onClick={() => pos !== 0 && setActiveIndex(i)}
                 >
-                  <h4 style={{ color: '#2451D7' }} className="text-2xl mb-2 text-left">{card.titulo}</h4>
-                  <div className="flex justify-center mb-4">
-                    <Image src={card.img} alt={card.titulo} width={64} height={64} />
+                  <h4
+                    style={{ color: "#2451D7" }}
+                    className="text-xl sm:text-2xl mb-3 sm:mb-4 text-center"
+                  >
+                    {card.titulo}
+                  </h4>
+                  <div className="flex justify-center mb-4 sm:mb-6">
+                    <Image
+                      src={card.img}
+                      alt={card.titulo}
+                      width={56}
+                      height={56}
+                      className="sm:w-16 sm:h-16"
+                    />
                   </div>
-                  <p style={{ color: '#1F1B3B' }} className="text-left mt-2">{card.desc}</p>
+                  <p
+                    style={{ color: "#1F1B3B" }}
+                    className="text-center text-sm sm:text-base leading-relaxed"
+                  >
+                    {card.desc}
+                  </p>
                 </div>
               );
             })}
           </div>
-          <div className="relative w-full h-[400px] flex items-center justify-center">
-            {["/pages/servicios/5-Servicios.webp", "/pages/servicios/5-Servicios2.webp"].map((img, idx) => (
+          <div className="relative w-full min-h-[350px] sm:min-h-[400px] flex items-center justify-center">
+            {[
+              "/pages/servicios/5-Servicios.webp",
+              "/pages/servicios/5-Servicios2.webp",
+            ].map((img, idx) => (
               <Image
                 key={img}
                 src={img}
                 alt={`Servicio ${idx + 1}`}
-                width={500}
-                height={500}
-                className={`object-contain rounded-xl shadow-lg absolute left-1/2 -translate-x-1/2 transition-opacity duration-500 ${activeIndex === idx ? 'opacity-100 z-10' : 'opacity-0 z-0'}`}
+                width={400}
+                height={400}
+                className={`object-contain rounded-xl shadow-lg absolute left-1/2 -translate-x-1/2 transition-opacity duration-500 w-[280px] sm:w-[350px] md:w-[400px] lg:w-[450px] h-auto ${
+                  activeIndex === idx ? "opacity-100 z-10" : "opacity-0 z-0"
+                }`}
               />
             ))}
           </div>
         </div>
       </section>
-      <section className="w-full flex flex-col items-center py-16">
-        <h2 className="text-2xl sm:text-3xl lg:text-4xl font-semibold mb-30 text-[#1F1B3B]">{t('productos_titulo')}</h2>
-        <div className="flex flex-col md:flex-row items-center justify-center w-full max-w-4xl mb-10">
+      <section className="w-full flex flex-col items-center py-12 sm:py-16 lg:py-20">
+        <h2 className="text-2xl sm:text-3xl lg:text-4xl font-semibold mb-12 sm:mb-16 lg:mb-20 text-[#1F1B3B] text-center px-4">
+          {t("productos_titulo")}
+        </h2>
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6 sm:gap-8 w-full max-w-6xl px-4">
           <div
-            className="flex flex-col items-center justify-center border-2 rounded-full w-72 h-72 -mx-3 aspect-square transition-all duration-300 group"
-            style={{ borderColor: 'var(--diametro-color)' }}
-            onMouseEnter={e => e.currentTarget.style.borderColor = 'var(--primary-border)'}
-            onMouseLeave={e => e.currentTarget.style.borderColor = 'var(--diametro-color)'}
+            className="flex flex-col items-center justify-center border-2 rounded-full w-60 h-60 sm:w-64 sm:h-64 lg:w-72 lg:h-72 mx-auto aspect-square transition-all duration-300 group"
+            style={{ borderColor: "var(--diametro-color)" }}
+            onMouseEnter={(e) =>
+              (e.currentTarget.style.borderColor = "var(--primary-border)")
+            }
+            onMouseLeave={(e) =>
+              (e.currentTarget.style.borderColor = "var(--diametro-color)")
+            }
           >
-            <h4 className="text-[#2451D7] text-lg font-semibold mb-2 text-center">
-              {t('productos.agregados').split('\n').map((line, idx) => (
-                <React.Fragment key={idx}>
-                  {line}
-                  {idx < t('productos.agregados').split('\n').length - 1 && <br />}
-                </React.Fragment>
-              ))}
+            <h4 className="text-[#2451D7] text-base sm:text-lg font-semibold mb-3 sm:mb-4 text-center px-2">
+              {t("productos.agregados")
+                .split("\n")
+                .map((line, idx) => (
+                  <React.Fragment key={idx}>
+                    {line}
+                    {idx < t("productos.agregados").split("\n").length - 1 && (
+                      <br />
+                    )}
+                  </React.Fragment>
+                ))}
             </h4>
             <Image
-              src={isDark ? "/pages/inicio/agregado-white.png" : "/pages/inicio/agregado.png"}
-              alt={t('productos.agregados').replace(/\n/g, ' ')}
-              width={140}
-              height={140}
-              className="mt-2 transition-transform duration-300 group-hover:scale-110"
+              src={
+                isDark
+                  ? "/pages/inicio/agregado-white.png"
+                  : "/pages/inicio/agregado.png"
+              }
+              alt={t("productos.agregados").replace(/\n/g, " ")}
+              width={120}
+              height={120}
+              className="transition-transform duration-300 group-hover:scale-110 w-20 h-20 sm:w-28 sm:h-28 lg:w-32 lg:h-32"
             />
           </div>
           <div
-            className="flex flex-col items-center justify-center border-2 rounded-full w-72 h-72 -mx-3 aspect-square transition-all duration-300 group"
-            style={{ borderColor: 'var(--diametro-color)' }}
-            onMouseEnter={e => e.currentTarget.style.borderColor = 'var(--primary-border)'}
-            onMouseLeave={e => e.currentTarget.style.borderColor = 'var(--diametro-color)'}
+            className="flex flex-col items-center justify-center border-2 rounded-full w-60 h-60 sm:w-64 sm:h-64 lg:w-72 lg:h-72 mx-auto aspect-square transition-all duration-300 group"
+            style={{ borderColor: "var(--diametro-color)" }}
+            onMouseEnter={(e) =>
+              (e.currentTarget.style.borderColor = "var(--primary-border)")
+            }
+            onMouseLeave={(e) =>
+              (e.currentTarget.style.borderColor = "var(--diametro-color)")
+            }
           >
-            <h4 className="text-[#2451D7] text-lg font-semibold mb-2 text-center">
-              {t('productos.adoquines').split('\n').map((line, idx) => (
-                <React.Fragment key={idx}>
-                  {line}
-                  {idx < t('productos.adoquines').split('\n').length - 1 && <br />}
-                </React.Fragment>
-              ))}
+            <h4 className="text-[#2451D7] text-base sm:text-lg font-semibold mb-3 sm:mb-4 text-center px-2">
+              {t("productos.adoquines")
+                .split("\n")
+                .map((line, idx) => (
+                  <React.Fragment key={idx}>
+                    {line}
+                    {idx < t("productos.adoquines").split("\n").length - 1 && (
+                      <br />
+                    )}
+                  </React.Fragment>
+                ))}
             </h4>
             <Image
-              src={isDark ? "/pages/inicio/adoquin-white.png" : "/pages/inicio/adoquin.png"}
-              alt={t('productos.adoquines').replace(/\n/g, ' ')}
-              width={140}
-              height={140}
-              className="mt-2 transition-transform duration-300 group-hover:scale-110"
+              src={
+                isDark
+                  ? "/pages/inicio/adoquin-white.png"
+                  : "/pages/inicio/adoquin.png"
+              }
+              alt={t("productos.adoquines").replace(/\n/g, " ")}
+              width={120}
+              height={120}
+              className="transition-transform duration-300 group-hover:scale-110 w-20 h-20 sm:w-28 sm:h-28 lg:w-32 lg:h-32"
             />
           </div>
           <div
-            className="flex flex-col items-center justify-center border-2 rounded-full w-72 h-72 -mx-3 aspect-square transition-all duration-300 group"
-            style={{ borderColor: 'var(--diametro-color)' }}
-            onMouseEnter={e => e.currentTarget.style.borderColor = 'var(--primary-border)'}
-            onMouseLeave={e => e.currentTarget.style.borderColor = 'var(--diametro-color)'}
+            className="flex flex-col items-center justify-center border-2 rounded-full w-60 h-60 sm:w-64 sm:h-64 lg:w-72 lg:h-72 mx-auto aspect-square transition-all duration-300 group"
+            style={{ borderColor: "var(--diametro-color)" }}
+            onMouseEnter={(e) =>
+              (e.currentTarget.style.borderColor = "var(--primary-border)")
+            }
+            onMouseLeave={(e) =>
+              (e.currentTarget.style.borderColor = "var(--diametro-color)")
+            }
           >
-            <h4 className="text-[#2451D7] text-lg font-semibold mb-2 text-center">
-              {t('productos.ladrillos').split('\n').map((line, idx) => (
-                <React.Fragment key={idx}>
-                  {line}
-                  {idx < t('productos.ladrillos').split('\n').length - 1 && <br />}
-                </React.Fragment>
-              ))}
+            <h4 className="text-[#2451D7] text-base sm:text-lg font-semibold mb-3 sm:mb-4 text-center px-2">
+              {t("productos.ladrillos")
+                .split("\n")
+                .map((line, idx) => (
+                  <React.Fragment key={idx}>
+                    {line}
+                    {idx < t("productos.ladrillos").split("\n").length - 1 && (
+                      <br />
+                    )}
+                  </React.Fragment>
+                ))}
             </h4>
             <Image
-              src={isDark ? "/pages/inicio/ladrillo-white.png" : "/pages/inicio/ladrillo.png"}
-              alt={t('productos.ladrillos').replace(/\n/g, ' ')}
-              width={140}
-              height={140}
-              className="mt-2 transition-transform duration-300 group-hover:scale-110"
+              src={
+                isDark
+                  ? "/pages/inicio/ladrillo-white.png"
+                  : "/pages/inicio/ladrillo.png"
+              }
+              alt={t("productos.ladrillos").replace(/\n/g, " ")}
+              width={120}
+              height={120}
+              className="transition-transform duration-300 group-hover:scale-110 w-20 h-20 sm:w-28 sm:h-28 lg:w-32 lg:h-32"
             />
           </div>
           <div
-            className="flex flex-col items-center justify-center border-2 rounded-full w-72 h-72 -mx-3 aspect-square transition-all duration-300 group"
-            style={{ borderColor: 'var(--diametro-color)' }}
-            onMouseEnter={e => e.currentTarget.style.borderColor = 'var(--primary-border)'}
-            onMouseLeave={e => e.currentTarget.style.borderColor = 'var(--diametro-color)'}
+            className="flex flex-col items-center justify-center border-2 rounded-full w-60 h-60 sm:w-64 sm:h-64 lg:w-72 lg:h-72 mx-auto aspect-square transition-all duration-300 group"
+            style={{ borderColor: "var(--diametro-color)" }}
+            onMouseEnter={(e) =>
+              (e.currentTarget.style.borderColor = "var(--primary-border)")
+            }
+            onMouseLeave={(e) =>
+              (e.currentTarget.style.borderColor = "var(--diametro-color)")
+            }
           >
-            <h4 className="text-[#2451D7] text-lg font-semibold mb-2 text-center">
-              {t('productos.separadores').split('\n').map((line, idx) => (
-                <React.Fragment key={idx}>
-                  {line}
-                  {idx < t('productos.separadores').split('\n').length - 1 && <br />}
-                </React.Fragment>
-              ))}
+            <h4 className="text-[#2451D7] text-base sm:text-lg font-semibold mb-3 sm:mb-4 text-center px-2">
+              {t("productos.separadores")
+                .split("\n")
+                .map((line, idx) => (
+                  <React.Fragment key={idx}>
+                    {line}
+                    {idx <
+                      t("productos.separadores").split("\n").length - 1 && (
+                      <br />
+                    )}
+                  </React.Fragment>
+                ))}
             </h4>
             <Image
-              src={isDark ? "/pages/inicio/separador-white.png" : "/pages/inicio/separador.png"}
-              alt={t('productos.separadores').replace(/\n/g, ' ')}
-              width={140}
-              height={140}
-              className="mt-2 transition-transform duration-300 group-hover:scale-110"
+              src={
+                isDark
+                  ? "/pages/inicio/separador-white.png"
+                  : "/pages/inicio/separador.png"
+              }
+              alt={t("productos.separadores").replace(/\n/g, " ")}
+              width={120}
+              height={120}
+              className="transition-transform duration-300 group-hover:scale-110 w-20 h-20 sm:w-28 sm:h-28 lg:w-32 lg:h-32"
             />
           </div>
         </div>
       </section>
-      <section className="relative bg-[#2451D7] py-40 mt-20">
-        <div className="max-w-6xl mx-auto flex flex-col md:flex-row items-center justify-between px-4">
-          <div className="w-full md:w-2/3 text-left">
-            <h3 className="text-xl sm:text-3xl mb-8">{t('cta.descripcion')}</h3>
+      <section className="relative bg-[#2451D7] py-16 sm:py-24 lg:py-32 mt-12 sm:mt-16 lg:mt-20">
+        <div className="max-w-6xl mx-auto flex flex-col lg:flex-row items-center justify-between px-4 sm:px-6 lg:px-8 gap-8">
+          <div className="w-full lg:w-2/3 text-center lg:text-left">
+            <h3 className="text-lg sm:text-xl lg:text-2xl xl:text-3xl mb-6 sm:mb-8 text-white leading-relaxed">
+              {t("cta.descripcion")}
+            </h3>
           </div>
-          <div className="w-full md:w-1/3 flex md:justify-end justify-center">
+          <div className="w-full lg:w-1/3 flex justify-center lg:justify-end">
             <button
-              className="bg-[#F2F2F2] text-[#1F1B3B] font-medium px-8 py-4 rounded-lg text-xl shadow transition-colors duration-200 cursor-pointer"
-              onClick={() => router.push('/contacto')}
+              className="bg-[#F2F2F2] text-[#1F1B3B] font-medium px-6 sm:px-8 py-3 sm:py-4 rounded-lg text-lg sm:text-xl shadow-lg hover:shadow-xl transition-all duration-200 cursor-pointer hover:bg-white transform hover:scale-105 w-full sm:w-auto"
+              onClick={() => router.push("/contacto")}
             >
-              {t('cta.boton')}
+              {t("cta.boton")}
             </button>
           </div>
         </div>
       </section>
-
     </>
   );
 }
-

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,4 +1,3 @@
-
 "use client";
 
 import React from "react";
@@ -6,67 +5,118 @@ import Image from "next/image";
 import { useTranslation } from "react-i18next";
 
 const Footer = () => {
-    const { t } = useTranslation("common");
-    return (
-        <footer className="bg-[#1F1B3B] text-[#F2F2F2] pt-20 pb-30 px-6 md:px-12 lg:px-32">
-            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-5 lg:grid-cols-5 gap-x-8 md:gap-x-10 lg:gap-x-16 gap-y-8 text-[#F2F2F2]">
-                <div className="sm:col-span-2 md:col-span-2 lg:col-span-2 flex flex-col min-w-[180px] md:max-w-sm lg:max-w-md">
-                    <div className="mb-1">
-                        <Image 
-                            src="/img/ciclo-white.png" 
-                            alt="Ciclo Logo" 
-                            width={140} 
-                            height={45}
-                            style={{ height: "auto" }}
-                        />
-                    </div>
-                    <h3 className="font-bricolage font-normal text-base md:text-sm lg:text-sm mb-8 text-[#F2F2F2] max-w-xs md:max-w-sm lg:max-w-md text-left break-words">{t('footer.descripcion')}</h3>
-                    <div className="flex gap-4 text-2xl text-[#4F5BFF]">
-                        <a href="#" aria-label="YouTube"><svg className="h-6 w-6" fill="currentColor" viewBox="0 0 24 24"><path d="M23.498 6.186a2.994 2.994 0 0 0-2.108-2.115C19.073 3.5 12 3.5 12 3.5s-7.073 0-9.39.571A2.994 2.994 0 0 0 .502 6.186C0 8.504 0 12 0 12s0 3.496.502 5.814a2.994 2.994 0 0 0 2.108 2.115C4.927 20.5 12 20.5 12 20.5s7.073 0 9.39-.571a2.994 2.994 0 0 0 2.108-2.115C24 15.496 24 12 24 12s0-3.496-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z" /></svg></a>
-                        <a href="#" aria-label="Facebook"><svg className="h-6 w-6" fill="currentColor" viewBox="0 0 24 24"><path d="M22.675 0h-21.35C.595 0 0 .592 0 1.326v21.348C0 23.408.595 24 1.326 24h11.495v-9.294H9.691v-3.622h3.13V8.413c0-3.1 1.893-4.788 4.659-4.788 1.325 0 2.463.099 2.797.143v3.24l-1.918.001c-1.504 0-1.797.715-1.797 1.763v2.313h3.587l-.467 3.622h-3.12V24h6.116C23.405 24 24 23.408 24 22.674V1.326C24 .592 23.405 0 22.675 0" /></svg></a>
-                        <a href="#" aria-label="Instagram"><svg className="h-6 w-6" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 1.366.062 2.633.334 3.608 1.308.974.974 1.246 2.241 1.308 3.608.058 1.266.07 1.646.07 4.85s-.012 3.584-.07 4.85c-.062 1.366-.334 2.633-1.308 3.608-.974.974-2.241 1.246-3.608 1.308-1.266.058-1.646.07-4.85.07s-3.584-.012-4.85-.07c-1.366-.062-2.633-.334-3.608-1.308-.974-.974-1.246-2.241-1.308-3.608C2.175 15.647 2.163 15.267 2.163 12s.012-3.584.07-4.85c.062-1.366.334-2.633 1.308-3.608C4.515 2.497 5.782 2.225 7.148 2.163 8.414 2.105 8.794 2.163 12 2.163zm0-2.163C8.741 0 8.332.013 7.052.072 5.771.131 4.659.417 3.678 1.398c-.98.98-1.267 2.092-1.326 3.374C2.013 5.668 2 6.077 2 12c0 5.923.013 6.332.072 7.612.059 1.282.346 2.394 1.326 3.374.981.981 2.093 1.267 3.374 1.326C8.332 23.987 8.741 24 12 24s3.668-.013 4.948-.072c1.281-.059 2.393-.345 3.374-1.326.98-.98 1.267-2.092 1.326-3.374.059-1.28.072-1.689.072-7.612 0-5.923-.013-6.332-.072-7.612-.059-1.282-.346-2.394-1.326-3.374-.981-.981-2.093-1.267-3.374-1.326C15.668.013 15.259 0 12 0z" /><circle cx="12" cy="12" r="3.5" /><circle cx="18.406" cy="5.594" r="1.44" /></svg></a>
-                        <a href="#" aria-label="LinkedIn"><svg className="h-6 w-6" fill="currentColor" viewBox="0 0 24 24"><path d="M19 0h-14c-2.761 0-5 2.239-5 5v14c0 2.761 2.239 5 5 5h14c2.761 0 5-2.239 5-5v-14c0-2.761-2.239-5-5-5zm-11 19h-3v-10h3v10zm-1.5-11.268c-.966 0-1.75-.784-1.75-1.75s.784-1.75 1.75-1.75 1.75.784 1.75 1.75-.784 1.75-1.75 1.75zm13.5 11.268h-3v-5.604c0-1.337-.026-3.063-1.868-3.063-1.868 0-2.154 1.459-2.154 2.967v5.7h-3v-10h2.881v1.367h.041c.401-.761 1.381-1.563 2.841-1.563 3.039 0 3.6 2.002 3.6 4.604v5.592z" /></svg></a>
-                    </div>
-                </div>
-                <div className="min-w-[120px]">
-                    <h3 className="font-bricolage font-medium text-lg md:text-xl lg:text-2xl mb-6">{t('footer.servicios')}</h3>
-                    <ul className="font-bricolage font-normal text-sm md:text-sm lg:text-sm space-y-4 text-[#F2F2F2]">
-                        <li className="text-base md:text-sm lg:text-sm">{t('footer.servicios_gestion')}</li>
-                        <li className="text-base md:text-sm lg:text-sm">{t('footer.servicios_reciclaje')}</li>
-                        <li className="text-base md:text-sm lg:text-sm">{t('footer.servicios_valorizacion')}</li>
-                    </ul>
-                </div>
-                <div className="min-w-[120px]">
-                    <h3 className="font-bricolage font-medium text-lg md:text-xl lg:text-2xl mb-6">{t('footer.productos')}</h3>
-                    <ul className="font-bricolage font-normal text-sm md:text-sm lg:text-sm space-y-4 text-[#F2F2F2]">
-                        <li className="text-base md:text-sm lg:text-sm">{t('footer.productos_ecoadoquines')}</li>
-                        <li className="text-base md:text-sm lg:text-sm">{t('footer.productos_bloques')}</li>
-                        <li className="text-base md:text-sm lg:text-sm">{t('footer.productos_agregados')}</li>
-                    </ul>
-                </div>
-                <div className="min-w-[150px]">
-                    <h3 className="font-bricolage font-medium text-lg md:text-xl lg:text-2xl mb-6">{t('footer.contacto')}</h3>
-                    <ul className="font-bricolage font-normal text-sm md:text-sm lg:text-sm space-y-4 text-[#F2F2F2]">
-                        <li className="text-base md:text-sm lg:text-sm">
-                            {t('footer.direccion').split('\n').map((line, i, arr) => (
-                                <React.Fragment key={i}>
-                                    {line}
-                                    {i < arr.length - 1 && <br />}
-                                </React.Fragment>
-                            ))}
-                        </li>
-                        <li className="text-base md:text-sm lg:text-sm">{t('footer.telefono')}</li>
-                        <li className="text-base md:text-sm lg:text-sm">{t('footer.email')}</li>
-                    </ul>
-                </div>
-            </div>
-            <div className="border-t border-[#C9A86A] my-6"></div>
-            <div className="flex flex-col md:flex-row justify-between text-base md:text-sm lg:text-sm items-center text-[#F2F2F2]/80 w-full">
-                <span className="w-full md:w-auto text-left truncate font-bricolage font-medium text-base md:text-sm lg:text-sm">{t('footer.copyright')}</span>
-                <a href="#" className="font-bricolage font-medium text-base md:text-sm lg:text-sm text-[#2451D7] hover:underline mt-2 md:mt-0">{t('footer.terminos')}</a>
-            </div>
-        </footer>
-    );
+  const { t } = useTranslation("common");
+  return (
+    <footer className="bg-[#1F1B3B] text-[#F2F2F2] pt-20 pb-30 px-6 md:px-12 lg:px-32">
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-5 lg:grid-cols-5 gap-x-8 md:gap-x-10 lg:gap-x-16 gap-y-8 text-[#F2F2F2]">
+        <div className="sm:col-span-2 md:col-span-2 lg:col-span-2 flex flex-col min-w-[180px] md:max-w-sm lg:max-w-md">
+          <div className="mb-1">
+            <Image
+              src="/img/ciclo-white.png"
+              alt="Ciclo Logo"
+              width={140}
+              height={45}
+              style={{ height: "auto" }}
+            />
+          </div>
+          <h3 className="font-bricolage font-normal text-base md:text-sm lg:text-sm mb-8 text-[#F2F2F2] max-w-xs md:max-w-sm lg:max-w-md text-left break-words">
+            {t("footer.descripcion")}
+          </h3>
+          <div className="flex gap-4 text-2xl text-[#4F5BFF]">
+            <a href="#" aria-label="YouTube">
+              <svg className="h-6 w-6" fill="currentColor" viewBox="0 0 24 24">
+                <path d="M23.498 6.186a2.994 2.994 0 0 0-2.108-2.115C19.073 3.5 12 3.5 12 3.5s-7.073 0-9.39.571A2.994 2.994 0 0 0 .502 6.186C0 8.504 0 12 0 12s0 3.496.502 5.814a2.994 2.994 0 0 0 2.108 2.115C4.927 20.5 12 20.5 12 20.5s7.073 0 9.39-.571a2.994 2.994 0 0 0 2.108-2.115C24 15.496 24 12 24 12s0-3.496-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z" />
+              </svg>
+            </a>
+            <a href="#" aria-label="Facebook">
+              <svg className="h-6 w-6" fill="currentColor" viewBox="0 0 24 24">
+                <path d="M22.675 0h-21.35C.595 0 0 .592 0 1.326v21.348C0 23.408.595 24 1.326 24h11.495v-9.294H9.691v-3.622h3.13V8.413c0-3.1 1.893-4.788 4.659-4.788 1.325 0 2.463.099 2.797.143v3.24l-1.918.001c-1.504 0-1.797.715-1.797 1.763v2.313h3.587l-.467 3.622h-3.12V24h6.116C23.405 24 24 23.408 24 22.674V1.326C24 .592 23.405 0 22.675 0" />
+              </svg>
+            </a>
+            <a href="#" aria-label="Instagram">
+              <svg className="h-6 w-6" fill="currentColor" viewBox="0 0 24 24">
+                <path d="M12 2.163c3.204 0 3.584.012 4.85.07 1.366.062 2.633.334 3.608 1.308.974.974 1.246 2.241 1.308 3.608.058 1.266.07 1.646.07 4.85s-.012 3.584-.07 4.85c-.062 1.366-.334 2.633-1.308 3.608-.974.974-2.241 1.246-3.608 1.308-1.266.058-1.646.07-4.85.07s-3.584-.012-4.85-.07c-1.366-.062-2.633-.334-3.608-1.308-.974-.974-1.246-2.241-1.308-3.608C2.175 15.647 2.163 15.267 2.163 12s.012-3.584.07-4.85c.062-1.366.334-2.633 1.308-3.608C4.515 2.497 5.782 2.225 7.148 2.163 8.414 2.105 8.794 2.163 12 2.163zm0-2.163C8.741 0 8.332.013 7.052.072 5.771.131 4.659.417 3.678 1.398c-.98.98-1.267 2.092-1.326 3.374C2.013 5.668 2 6.077 2 12c0 5.923.013 6.332.072 7.612.059 1.282.346 2.394 1.326 3.374.981.981 2.093 1.267 3.374 1.326C8.332 23.987 8.741 24 12 24s3.668-.013 4.948-.072c1.281-.059 2.393-.345 3.374-1.326.98-.98 1.267-2.092 1.326-3.374.059-1.28.072-1.689.072-7.612 0-5.923-.013-6.332-.072-7.612-.059-1.282-.346-2.394-1.326-3.374-.981-.981-2.093-1.267-3.374-1.326C15.668.013 15.259 0 12 0z" />
+                <circle cx="12" cy="12" r="3.5" />
+                <circle cx="18.406" cy="5.594" r="1.44" />
+              </svg>
+            </a>
+            <a href="#" aria-label="LinkedIn">
+              <svg className="h-6 w-6" fill="currentColor" viewBox="0 0 24 24">
+                <path d="M19 0h-14c-2.761 0-5 2.239-5 5v14c0 2.761 2.239 5 5 5h14c2.761 0 5-2.239 5-5v-14c0-2.761-2.239-5-5-5zm-11 19h-3v-10h3v10zm-1.5-11.268c-.966 0-1.75-.784-1.75-1.75s.784-1.75 1.75-1.75 1.75.784 1.75 1.75-.784 1.75-1.75 1.75zm13.5 11.268h-3v-5.604c0-1.337-.026-3.063-1.868-3.063-1.868 0-2.154 1.459-2.154 2.967v5.7h-3v-10h2.881v1.367h.041c.401-.761 1.381-1.563 2.841-1.563 3.039 0 3.6 2.002 3.6 4.604v5.592z" />
+              </svg>
+            </a>
+          </div>
+        </div>
+        <div className="min-w-[120px]">
+          <h3 className="font-bricolage font-medium text-lg md:text-xl lg:text-2xl mb-6">
+            {t("footer.servicios")}
+          </h3>
+          <ul className="font-bricolage font-normal text-sm md:text-sm lg:text-sm space-y-4 text-[#F2F2F2]">
+            <li className="text-base md:text-sm lg:text-sm">
+              {t("footer.servicios_gestion")}
+            </li>
+            <li className="text-base md:text-sm lg:text-sm">
+              {t("footer.servicios_reciclaje")}
+            </li>
+            <li className="text-base md:text-sm lg:text-sm">
+              {t("footer.servicios_valorizacion")}
+            </li>
+          </ul>
+        </div>
+        <div className="min-w-[120px]">
+          <h3 className="font-bricolage font-medium text-lg md:text-xl lg:text-2xl mb-6">
+            {t("footer.productos")}
+          </h3>
+          <ul className="font-bricolage font-normal text-sm md:text-sm lg:text-sm space-y-4 text-[#F2F2F2]">
+            <li className="text-base md:text-sm lg:text-sm">
+              {t("footer.productos_ecoadoquines")}
+            </li>
+            <li className="text-base md:text-sm lg:text-sm">
+              {t("footer.productos_bloques")}
+            </li>
+            <li className="text-base md:text-sm lg:text-sm">
+              {t("footer.productos_agregados")}
+            </li>
+          </ul>
+        </div>
+        <div className="min-w-[150px]">
+          <h3 className="font-bricolage font-medium text-lg md:text-xl lg:text-2xl mb-6">
+            {t("footer.contacto")}
+          </h3>
+          <ul className="font-bricolage font-normal text-sm md:text-sm lg:text-sm space-y-4 text-[#F2F2F2]">
+            <li className="text-base md:text-sm lg:text-sm">
+              {t("footer.direccion")
+                .split("\n")
+                .map((line, i, arr) => (
+                  <React.Fragment key={i}>
+                    {line}
+                    {i < arr.length - 1 && <br />}
+                  </React.Fragment>
+                ))}
+            </li>
+            <li className="text-base md:text-sm lg:text-sm">
+              {t("footer.telefono")}
+            </li>
+            <li className="text-base md:text-sm lg:text-sm">
+              {t("footer.email")}
+            </li>
+          </ul>
+        </div>
+      </div>
+      <div className="border-t border-[#C9A86A] my-6"></div>
+      <div className="flex flex-col md:flex-row justify-between text-base md:text-sm lg:text-sm items-center text-[#F2F2F2]/80 w-full">
+        <span className="w-full md:w-auto text-left truncate font-bricolage font-medium text-base md:text-sm lg:text-sm">
+          {t("footer.copyright")}
+        </span>
+        <a
+          href="#"
+          className="font-bricolage font-medium text-base md:text-sm lg:text-sm text-[#2451D7] hover:underline mt-2 md:mt-0"
+        >
+          {t("footer.terminos")}
+        </a>
+      </div>
+    </footer>
+  );
 };
 
 export default Footer;

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -12,7 +12,13 @@ const Footer = () => {
             <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-5 lg:grid-cols-5 gap-x-8 md:gap-x-10 lg:gap-x-16 gap-y-8 text-[#F2F2F2]">
                 <div className="sm:col-span-2 md:col-span-2 lg:col-span-2 flex flex-col min-w-[180px] md:max-w-sm lg:max-w-md">
                     <div className="mb-1">
-                        <Image src="/img/ciclo-white.png" alt="Ciclo Logo" width={140} height={45} />
+                        <Image 
+                            src="/img/ciclo-white.png" 
+                            alt="Ciclo Logo" 
+                            width={140} 
+                            height={45}
+                            style={{ height: "auto" }}
+                        />
                     </div>
                     <h3 className="font-bricolage font-normal text-base md:text-sm lg:text-sm mb-8 text-[#F2F2F2] max-w-xs md:max-w-sm lg:max-w-md text-left break-words">{t('footer.descripcion')}</h3>
                     <div className="flex gap-4 text-2xl text-[#4F5BFF]">

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,15 +1,45 @@
 import { Canvas, useFrame, useLoader } from "@react-three/fiber";
 import { OrbitControls, Cylinder, Plane } from "@react-three/drei";
-import { useRef, useMemo } from "react";
+import { useRef, useMemo, useState, useEffect } from "react";
 import * as THREE from "three";
 import { useTranslation } from "react-i18next";
 import Image from "next/image";
 
-function createTextCanvas(text: string, color: string) {
-  const fontSize = 200;
+function useWindowSize() {
+  const [windowSize, setWindowSize] = useState({
+    width: typeof window !== "undefined" ? window.innerWidth : 1024,
+    height: typeof window !== "undefined" ? window.innerHeight : 768,
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    function handleResize() {
+      setWindowSize({
+        width: window.innerWidth,
+        height: window.innerHeight,
+      });
+    }
+
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
+  return windowSize;
+}
+
+function createTextCanvas(
+  text: string,
+  color: string,
+  windowWidth: number = 1024
+) {
   const canvas = document.createElement("canvas");
-  canvas.width = 3072;
-  canvas.height = 320;
+  const scale = windowWidth < 768 ? 0.7 : 1;
+  const fontSize = 200 * scale;
+
+  canvas.width = 3072 * scale;
+  canvas.height = 320 * scale;
+
   const ctx = canvas.getContext("2d");
   if (ctx) {
     ctx.clearRect(0, 0, canvas.width, canvas.height);
@@ -25,9 +55,17 @@ function createTextCanvas(text: string, color: string) {
 type TextRingProps = {
   text?: string;
   color?: string;
+  windowWidth?: number;
 };
-function TextRing({ text = "Transformar para inspirar", color = "#2451D7" }: TextRingProps) {
-  const canvas = useMemo(() => createTextCanvas(text, color), [text, color]);
+function TextRing({
+  text = "Transformar para inspirar",
+  color = "#2451D7",
+  windowWidth = 1024,
+}: TextRingProps) {
+  const canvas = useMemo(
+    () => createTextCanvas(text, color, windowWidth),
+    [text, color, windowWidth]
+  );
   const textureRef = useRef<THREE.CanvasTexture | null>(null);
   useFrame(({ clock }) => {
     if (textureRef.current && textureRef.current.offset) {
@@ -35,7 +73,7 @@ function TextRing({ text = "Transformar para inspirar", color = "#2451D7" }: Tex
     }
   });
   return (
-    <Cylinder args={[5, 5, 1, 200, 1, true]} position={[0, -0.6, -0.2]}>
+    <Cylinder args={[8, 8, 1.6, 200, 1, true]} position={[0, -1.2, -0.5]}>
       <meshStandardMaterial
         transparent
         attach="material"
@@ -50,7 +88,7 @@ function TextRing({ text = "Transformar para inspirar", color = "#2451D7" }: Tex
           wrapS={THREE.RepeatWrapping}
           wrapT={THREE.RepeatWrapping}
           repeat={[3, 1]}
-          onUpdate={s => (s.needsUpdate = true)}
+          onUpdate={(s) => (s.needsUpdate = true)}
         />
       </meshStandardMaterial>
     </Cylinder>
@@ -59,48 +97,112 @@ function TextRing({ text = "Transformar para inspirar", color = "#2451D7" }: Tex
 
 type CenterImageProps = {
   src: string;
+  windowWidth?: number;
 };
-function CenterImage({ src }: CenterImageProps) {
+function CenterImage({ src, windowWidth = 1024 }: CenterImageProps) {
   const texture = useLoader(THREE.TextureLoader, src) as THREE.Texture;
+
+  const getImageScale = () => {
+    const width = windowWidth;
+    // Tamaños aumentados para mejor visibilidad
+    if (width < 640) return { width: 8, height: 10.5 }; // mobile - mucho más grande
+    if (width < 768) return { width: 9.5, height: 12.5 }; // sm - mucho más grande
+    if (width < 1024) return { width: 11.5, height: 15 }; // md - mucho más grande
+    if (width < 1280) return { width: 13.5, height: 17.5 }; // lg - mucho más grande
+    return { width: 16, height: 21 }; // xl+ - considerablemente más grande
+  };
+
+  const imageScale = getImageScale();
+
   return (
-    <Plane args={[7.5, 10]} position={[0, -0.3, 0]} rotation={[0, 0, 0]}>
+    <Plane
+      args={[imageScale.width, imageScale.height]}
+      position={[0, -0.5, 0]}
+      rotation={[0, 0, 0]}
+    >
       <meshBasicMaterial attach="material" map={texture} transparent />
     </Plane>
   );
 }
 
-
-
 export default function Hero() {
   const { t } = useTranslation("inicio");
+  const windowSize = useWindowSize();
+
+  const getCanvasSize = () => {
+    const width = windowSize.width;
+    if (width < 640)
+      return {
+        width: Math.min(480, width - 20),
+        height: Math.min(480, width - 20),
+      }; // mobile
+    if (width < 768) return { width: 600, height: 600 }; // sm
+    if (width < 1024) return { width: 700, height: 700 }; // md
+    if (width < 1280) return { width: 800, height: 800 }; // lg
+    return { width: 950, height: 950 }; // xl+
+  };
+
+  const canvasSize = getCanvasSize();
+
   return (
-    <main className="relative z-10 max-w-7xl mx-auto px-6 lg:px-8 py-3">
-      <div className="flex flex-col md:flex-row justify-between items-center min-h-[80vh] g-60">
+    <main className="relative z-10 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 sm:py-6 lg:py-8">
+      <div className="flex flex-col lg:flex-row justify-between items-center min-h-[60vh] sm:min-h-[70vh] lg:min-h-[80vh] gap-8 lg:gap-12">
         {/* Lado izquierdo: contenido original */}
-        <div className="w-full md:w-1/2 flex flex-col justify-center items-start mb-10 md:mb-0">
-          <h1 className="text-4xl sm:text-5xl lg:text-6xl font-bold text-[#2451D7] mb-6">
-            {t('hero_titulo')}
+        <div className="w-full lg:w-1/2 flex flex-col justify-center items-start text-center sm:text-left order-2 lg:order-1">
+          <h1 className="text-3xl sm:text-4xl md:text-5xl lg:text-6xl xl:text-7xl font-bold text-[#2451D7] mb-4 sm:mb-6 leading-tight">
+            {t("hero_titulo")}
           </h1>
-          <p className="text-lg sm:text-xl lg:text-2xl text-[#1F1B3B] mb-8 max-w-lg">
-            {t('hero_texto')}
+          <p className="text-base sm:text-lg md:text-xl lg:text-2xl text-[#1F1B3B] mb-6 sm:mb-8 max-w-lg mx-auto sm:mx-0 leading-relaxed">
+            {t("hero_texto")}
           </p>
           <button
-            className="bg-[#FFD34E] text-[#1F1B3B] font-medium px-8 py-4 rounded-lg text-xl shadow transition-colors duration-200 cursor-pointer"
-            onClick={() => window.location.href = '/contacto'}
+            className="bg-[#FFD34E] text-[#1F1B3B] font-medium px-6 sm:px-8 py-3 sm:py-4 rounded-lg text-lg sm:text-xl shadow-lg hover:shadow-xl transition-all duration-200 cursor-pointer hover:bg-[#FFE066] transform hover:scale-105 w-full sm:w-auto"
+            onClick={() => (window.location.href = "/contacto")}
           >
-            {t('hero_boton')}
+            {t("hero_boton")}
           </button>
         </div>
+
         {/* Lado derecho: efecto 3D */}
-        <div className="w-full md:w-1/2 flex justify-center items-center">
-          <div style={{ width: 600, height: 600, position: 'relative' }}>
+        <div className="w-full lg:w-1/2 flex justify-center items-center order-1 lg:order-2">
+          <div
+            className="relative"
+            style={{
+              width: canvasSize.width,
+              height: canvasSize.height,
+              maxWidth: "100%",
+              aspectRatio: "1",
+            }}
+          >
             <Canvas
-              style={{ width: 600, height: 600, background: 'transparent', borderRadius: '50%' }}
-              camera={{ position: [0, 0, 12], fov: 50 }}
+              style={{
+                width: "100%",
+                height: "100%",
+                background: "transparent",
+                borderRadius: "50%",
+              }}
+              camera={{ position: [0, 0, 22], fov: 65 }}
+              dpr={Math.min(
+                typeof window !== "undefined" ? window.devicePixelRatio : 1,
+                2
+              )}
             >
               <ambientLight intensity={-0.82} />
-              <TextRing text="Transformar para inspirar" color={getComputedStyle(document.documentElement).getPropertyValue('--orb-color').trim() || '#2451D7'} />
-              <CenterImage src="/img/worker.png" />
+              <TextRing
+                text="Transformar para inspirar"
+                windowWidth={windowSize.width}
+                color={
+                  typeof window !== "undefined"
+                    ? getComputedStyle(document.documentElement)
+                        .getPropertyValue("--orb-color")
+                        .trim() || "#2451D7"
+                    : "#2451D7"
+                }
+              />
+              <CenterImage
+                src="/img/worker.png"
+                windowWidth={windowSize.width}
+              />
             </Canvas>
           </div>
         </div>

--- a/components/I18nProvider.tsx
+++ b/components/I18nProvider.tsx
@@ -1,24 +1,36 @@
 "use client";
 import { I18nextProvider } from "react-i18next";
 import i18n from "../utils/i18n";
+import { useTheme } from "../context/ThemeContext";
 
 import { useEffect, useState } from "react";
 
 export default function I18nProvider({ children }: { children: React.ReactNode }) {
     const [ready, setReady] = useState(false);
+    const [mounted, setMounted] = useState(false);
+    const { theme } = useTheme();
 
     useEffect(() => {
-        const timer = setTimeout(() => {
-            setReady(true);
-        }, 500);
-        return () => clearTimeout(timer);
-    }, [i18n.language]);
+        setMounted(true);
+    }, []);
 
-    if (!ready) {
+    useEffect(() => {
+        if (mounted) {
+            const timer = setTimeout(() => {
+                setReady(true);
+            }, 500);
+            return () => clearTimeout(timer);
+        }
+    }, [i18n.language, mounted]);
+
+    if (!mounted || !ready) {
         return (
-            <div className="w-screen h-screen flex items-center justify-center bg-[#F2F2F2] dark:bg-[#1F1B3B]">
-                {/*                 <img src="/img/ciclo-logo.png" alt="Ciclo Logo" className="h-20 w-auto dark:hidden" />
- */}                <img src="/img/ciclo-white.png" alt="Ciclo Logo White" className="h-20 w-auto hidden dark:block" />
+            <div className={`w-screen h-screen flex items-center justify-center ${theme === 'dark' ? 'bg-[#1F1B3B]' : 'bg-[#F2F2F2]'}`}>
+                {theme === 'dark' ? (
+                    <img src="/img/ciclo-white.png" alt="Ciclo Logo White" className="h-20 w-auto" />
+                ) : (
+                    <img src="/img/ciclo-logo.png" alt="Ciclo Logo" className="h-20 w-auto" />
+                )}
             </div>
         );
     }

--- a/components/I18nProvider.tsx
+++ b/components/I18nProvider.tsx
@@ -5,34 +5,50 @@ import { useTheme } from "../context/ThemeContext";
 
 import { useEffect, useState } from "react";
 
-export default function I18nProvider({ children }: { children: React.ReactNode }) {
-    const [ready, setReady] = useState(false);
-    const [mounted, setMounted] = useState(false);
-    const { theme } = useTheme();
+export default function I18nProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [ready, setReady] = useState(false);
+  const [mounted, setMounted] = useState(false);
+  const { theme } = useTheme();
 
-    useEffect(() => {
-        setMounted(true);
-    }, []);
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
-    useEffect(() => {
-        if (mounted) {
-            const timer = setTimeout(() => {
-                setReady(true);
-            }, 500);
-            return () => clearTimeout(timer);
-        }
-    }, [i18n.language, mounted]);
-
-    if (!mounted || !ready) {
-        return (
-            <div className={`w-screen h-screen flex items-center justify-center ${theme === 'dark' ? 'bg-[#1F1B3B]' : 'bg-[#F2F2F2]'}`}>
-                {theme === 'dark' ? (
-                    <img src="/img/ciclo-white.png" alt="Ciclo Logo White" className="h-20 w-auto" />
-                ) : (
-                    <img src="/img/ciclo-logo.png" alt="Ciclo Logo" className="h-20 w-auto" />
-                )}
-            </div>
-        );
+  useEffect(() => {
+    if (mounted) {
+      const timer = setTimeout(() => {
+        setReady(true);
+      }, 500);
+      return () => clearTimeout(timer);
     }
-    return <I18nextProvider i18n={i18n}>{children}</I18nextProvider>;
+  }, [i18n.language, mounted]);
+
+  if (!mounted || !ready) {
+    return (
+      <div
+        className={`w-screen h-screen flex items-center justify-center ${
+          theme === "dark" ? "bg-[#1F1B3B]" : "bg-[#F2F2F2]"
+        }`}
+      >
+        {theme === "dark" ? (
+          <img
+            src="/img/ciclo-white.png"
+            alt="Ciclo Logo White"
+            className="h-20 w-auto"
+          />
+        ) : (
+          <img
+            src="/img/ciclo-logo.png"
+            alt="Ciclo Logo"
+            className="h-20 w-auto"
+          />
+        )}
+      </div>
+    );
+  }
+  return <I18nextProvider i18n={i18n}>{children}</I18nextProvider>;
 }

--- a/context/ThemeContext.tsx
+++ b/context/ThemeContext.tsx
@@ -1,48 +1,53 @@
 "use client";
 
-import React, { createContext, useContext, useEffect, useState } from 'react';
+import React, { createContext, useContext, useEffect, useState } from "react";
 
 interface ThemeContextType {
-    theme: 'light' | 'dark';
-    toggleTheme: () => void;
+  theme: "light" | "dark";
+  toggleTheme: () => void;
 }
 
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
-export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-    const [theme, setTheme] = useState<'light' | 'dark'>('light');
-    const [mounted, setMounted] = useState(false);
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [theme, setTheme] = useState<"light" | "dark">("light");
+  const [mounted, setMounted] = useState(false);
 
-    useEffect(() => {
-        setMounted(true);
-        if (typeof window !== 'undefined') {
-            const storedTheme = localStorage.getItem('theme');
-            const initialTheme = storedTheme === 'dark' ? 'dark' : 'light';
-            setTheme(initialTheme);
-            document.documentElement.classList.toggle('dark', initialTheme === 'dark');
-        }
-    }, []);
+  useEffect(() => {
+    setMounted(true);
+    if (typeof window !== "undefined") {
+      const storedTheme = localStorage.getItem("theme");
+      const initialTheme = storedTheme === "dark" ? "dark" : "light";
+      setTheme(initialTheme);
+      document.documentElement.classList.toggle(
+        "dark",
+        initialTheme === "dark"
+      );
+    }
+  }, []);
 
-    useEffect(() => {
-        if (mounted) {
-            document.documentElement.classList.toggle('dark', theme === 'dark');
-            localStorage.setItem('theme', theme);
-        }
-    }, [theme, mounted]);
+  useEffect(() => {
+    if (mounted) {
+      document.documentElement.classList.toggle("dark", theme === "dark");
+      localStorage.setItem("theme", theme);
+    }
+  }, [theme, mounted]);
 
-    const toggleTheme = () => {
-        setTheme((prev) => (prev === 'light' ? 'dark' : 'light'));
-    };
+  const toggleTheme = () => {
+    setTheme((prev) => (prev === "light" ? "dark" : "light"));
+  };
 
-    return (
-        <ThemeContext.Provider value={{ theme, toggleTheme }}>
-            {children}
-        </ThemeContext.Provider>
-    );
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
 };
 
 export const useTheme = () => {
-    const context = useContext(ThemeContext);
-    if (!context) throw new Error('useTheme must be used within a ThemeProvider');
-    return context;
+  const context = useContext(ThemeContext);
+  if (!context) throw new Error("useTheme must be used within a ThemeProvider");
+  return context;
 };

--- a/context/ThemeContext.tsx
+++ b/context/ThemeContext.tsx
@@ -10,18 +10,25 @@ interface ThemeContextType {
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
 export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-    const [theme, setTheme] = useState<'light' | 'dark'>(() => {
-        if (typeof window !== 'undefined') {
-            const storedTheme = localStorage.getItem('theme');
-            return storedTheme === 'dark' ? 'dark' : 'light';
-        }
-        return 'light';
-    });
+    const [theme, setTheme] = useState<'light' | 'dark'>('light');
+    const [mounted, setMounted] = useState(false);
 
     useEffect(() => {
-        document.documentElement.classList.toggle('dark', theme === 'dark');
-        localStorage.setItem('theme', theme);
-    }, [theme]);
+        setMounted(true);
+        if (typeof window !== 'undefined') {
+            const storedTheme = localStorage.getItem('theme');
+            const initialTheme = storedTheme === 'dark' ? 'dark' : 'light';
+            setTheme(initialTheme);
+            document.documentElement.classList.toggle('dark', initialTheme === 'dark');
+        }
+    }, []);
+
+    useEffect(() => {
+        if (mounted) {
+            document.documentElement.classList.toggle('dark', theme === 'dark');
+            localStorage.setItem('theme', theme);
+        }
+    }, [theme, mounted]);
 
     const toggleTheme = () => {
         setTheme((prev) => (prev === 'light' ? 'dark' : 'light'));


### PR DESCRIPTION
This pull request updates the `app/inicio/page.tsx` file to significantly improve the visual layout, responsiveness, and accessibility of the homepage sections. The changes focus on modernizing the design, enhancing mobile support, and refining the code style for consistency. There are also minor formatting tweaks in `components/Footer.tsx`.

**UI/UX and Responsiveness Improvements:**

* Refactored all major sections (hero, circularity, services, products, and CTA) to use more responsive paddings, margins, and layout classes for better appearance across device sizes. Adjusted section heights, spacing, and alignment to improve readability and visual hierarchy.
* Redesigned the "circularidad" (circularity) SVG and layout: now uses relative sizing, improved aspect ratio handling, more consistent positioning of images/text, and better adapts to dark mode.
* Updated the services and products cards to use grid/flex layouts, improved scaling and spacing, and enhanced hover/focus states for accessibility and interactivity.

**Code Style and Consistency:**

* Standardized usage of double quotes across JSX and JavaScript, and improved code formatting for readability. [[1]](diffhunk://#diff-b76683e8acaf5a6831afb457cd1f9159f9564dce2f9cae82187d972d32dfa594L1-R1) [[2]](diffhunk://#diff-b76683e8acaf5a6831afb457cd1f9159f9564dce2f9cae82187d972d32dfa594L30-L301)
* Refactored inline event handlers and style objects for clarity and consistency, including arrow function usage and object property formatting.

**Minor changes:**

* Removed an unnecessary blank line at the top of `components/Footer.tsx` for code cleanliness.

**Evidence**

<img width="720" height="1377" alt="image" src="https://github.com/user-attachments/assets/29644c27-a258-41ae-8908-ef4425f11b91" />

<img width="735" height="1395" alt="image" src="https://github.com/user-attachments/assets/35bc7896-1299-4bdb-9a74-51509d548a51" />

<img width="630" height="929" alt="image" src="https://github.com/user-attachments/assets/0a293826-f518-46dd-9f00-dc6186dc1879" />
