### PR TITLE
Feat/fixes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*.mp4 filter=lfs diff=lfs merge=lfs -text

--- a/public/videos/video.mp4
+++ b/public/videos/video.mp4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b73cb2cdd08f12a225f1df77c06308f6a5f6bdc48fcfb959362e671dec7c5706
-size 3740742

--- a/public/videos/video_h264.mp4
+++ b/public/videos/video_h264.mp4
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:86d4eb2250fc944d86fe09616f15672fbb87f055c760b399353eb37b5d81c28d
-size 31549402


### PR DESCRIPTION
This pull request removes Git LFS (Large File Storage) support for `.mp4` files and deletes the tracked video file from the repository. These changes help reduce repository size and simplify file management.

Repository configuration cleanup:
* Removed the Git LFS filter for `.mp4` files from `.gitattributes`, so future `.mp4` files will no longer be tracked using LFS.

Asset removal:
* Deleted the LFS-tracked video file `public/videos/video.mp4` from the repository.