### PR TITLE
feat: update comments 19sep

### DIFF
--- a/app/inicio/page.tsx
+++ b/app/inicio/page.tsx
@@ -141,7 +141,7 @@ export default function Home() {
                 >
                   <Image src={isDark ? "/pages/inicio/residuos-white.png" : "/pages/inicio/residuos.png"}
                     alt={t('circularidad_residuos_alt')}
-                    width={200}
+                    width={230}
                     height={60} />
                 </div>
                 <div
@@ -156,7 +156,7 @@ export default function Home() {
                   <Image
                     src={isDark ? "/pages/inicio/materiales-white.png" : "/pages/inicio/materiales.png"}
                     alt={t('circularidad_materiales_alt')}
-                    width={200}
+                    width={230}
                     height={60}
                   />
                 </div>
@@ -325,12 +325,12 @@ export default function Home() {
 
           <div className="flex flex-col md:flex-row items-center justify-center w-full max-w-4xl mb-10">
             <div
-              className="flex flex-col items-center justify-center border-2 rounded-full w-72 h-72 aspect-square transition-all duration-300 group"
+              className="flex flex-col items-center justify-center border-2 rounded-full w-65 h-65 aspect-square transition-all duration-300 group"
               style={{ borderColor: 'var(--diametro-color)' }}
               onMouseEnter={e => e.currentTarget.style.borderColor = 'var(--primary-border)'}
               onMouseLeave={e => e.currentTarget.style.borderColor = 'var(--diametro-color)'}
             >
-              <h4 className="text-[#2451D7] text-lg font-semibold mb-2 text-center">
+              <h4 className="text-[#2451D7] text-lg font-semibold mt-4 text-center">
                 {t('productos.agregados').split('\n').map((line, idx) => (
                   <React.Fragment key={idx}>
                     {line}
@@ -347,12 +347,12 @@ export default function Home() {
               />
             </div>
             <div
-              className="flex flex-col items-center justify-center border-2 rounded-full w-72 h-72 -mx-3 aspect-square transition-all duration-300 group"
+              className="flex flex-col items-center justify-center border-2 rounded-full w-65 h-65 -mx-3 aspect-square transition-all duration-300 group"
               style={{ borderColor: 'var(--diametro-color)' }}
               onMouseEnter={e => e.currentTarget.style.borderColor = 'var(--primary-border)'}
               onMouseLeave={e => e.currentTarget.style.borderColor = 'var(--diametro-color)'}
             >
-              <h4 className="text-[#2451D7] text-lg font-semibold mb-2 text-center">
+              <h4 className="text-[#2451D7] text-lg font-semibold mt-4 text-center">
                 {t('productos.adoquines').split('\n').map((line, idx) => (
                   <React.Fragment key={idx}>
                     {line}
@@ -369,12 +369,12 @@ export default function Home() {
               />
             </div>
             <div
-              className="flex flex-col items-center justify-center border-2 rounded-full w-72 h-72 -mx-3 aspect-square transition-all duration-300 group"
+              className="flex flex-col items-center justify-center border-2 rounded-full w-65 h-65 -mx-3 aspect-square transition-all duration-300 group"
               style={{ borderColor: 'var(--diametro-color)' }}
               onMouseEnter={e => e.currentTarget.style.borderColor = 'var(--primary-border)'}
               onMouseLeave={e => e.currentTarget.style.borderColor = 'var(--diametro-color)'}
             >
-              <h4 className="text-[#2451D7] text-lg font-semibold mb-2 text-center">
+              <h4 className="text-[#2451D7] text-lg font-semibold mt-4 text-center">
                 {t('productos.ladrillos').split('\n').map((line, idx) => (
                   <React.Fragment key={idx}>
                     {line}
@@ -391,12 +391,12 @@ export default function Home() {
               />
             </div>
             <div
-              className="flex flex-col items-center justify-center border-2 rounded-full w-72 h-72 -mx-3 aspect-square transition-all duration-300 group"
+              className="flex flex-col items-center justify-center border-2 rounded-full w-65 h-65 -mx-3 aspect-square transition-all duration-300 group"
               style={{ borderColor: 'var(--diametro-color)' }}
               onMouseEnter={e => e.currentTarget.style.borderColor = 'var(--primary-border)'}
               onMouseLeave={e => e.currentTarget.style.borderColor = 'var(--diametro-color)'}
             >
-              <h4 className="text-[#2451D7] text-lg font-semibold mb-2 text-center">
+              <h4 className="text-[#2451D7] text-lg font-semibold mt-4 text-center">
                 {t('productos.separadores').split('\n').map((line, idx) => (
                   <React.Fragment key={idx}>
                     {line}

--- a/public/locales/es/contacto.json
+++ b/public/locales/es/contacto.json
@@ -1,5 +1,5 @@
 {
-    "titulo": "¡Nos gustaría saber de ti !",
+    "titulo": "¡Nos gustaría saber de ti!",
     "descripcion": "Si tiene alguna consulta o simplemente quiere saludarnos, utilice el formulario de contacto.",
     "nombre": "Nombre",
     "email": "Email",


### PR DESCRIPTION
This pull request makes visual adjustments to the `Home` component in `app/inicio/page.tsx`, primarily focusing on resizing images and circular product display containers, as well as tweaking text spacing for improved layout and consistency.

Layout and sizing adjustments:

* Increased the width of the `residuos` and `materiales` images from 200px to 230px for better visibility. [[1]](diffhunk://#diff-b76683e8acaf5a6831afb457cd1f9159f9564dce2f9cae82187d972d32dfa594L144-R144) [[2]](diffhunk://#diff-b76683e8acaf5a6831afb457cd1f9159f9564dce2f9cae82187d972d32dfa594L159-R159)
* Reduced the size of circular product containers from `w-72 h-72` to `w-65 h-65` to create a more compact layout for product displays. [[1]](diffhunk://#diff-b76683e8acaf5a6831afb457cd1f9159f9564dce2f9cae82187d972d32dfa594L328-R333) [[2]](diffhunk://#diff-b76683e8acaf5a6831afb457cd1f9159f9564dce2f9cae82187d972d32dfa594L350-R355) [[3]](diffhunk://#diff-b76683e8acaf5a6831afb457cd1f9159f9564dce2f9cae82187d972d32dfa594L372-R377) [[4]](diffhunk://#diff-b76683e8acaf5a6831afb457cd1f9159f9564dce2f9cae82187d972d32dfa594L394-R399)

Text spacing improvements:

* Changed the margin on product titles from `mb-2` (bottom margin) to `mt-4` (top margin) for better alignment and spacing within the circular containers. [[1]](diffhunk://#diff-b76683e8acaf5a6831afb457cd1f9159f9564dce2f9cae82187d972d32dfa594L328-R333) [[2]](diffhunk://#diff-b76683e8acaf5a6831afb457cd1f9159f9564dce2f9cae82187d972d32dfa594L350-R355) [[3]](diffhunk://#diff-b76683e8acaf5a6831afb457cd1f9159f9564dce2f9cae82187d972d32dfa594L372-R377) [[4]](diffhunk://#diff-b76683e8acaf5a6831afb457cd1f9159f9564dce2f9cae82187d972d32dfa594L394-R399)