### PR TITLE
fix: documents names en es

### DIFF
--- a/public/locales/en/nosotros.json
+++ b/public/locales/en/nosotros.json
@@ -43,23 +43,23 @@
     "politicas_intro": "Access our policies that are part of our Integrated Management System and reflect our commitment to quality, environmental care, and safety.",
     "politicas": [
         {
-            "titulo": "Política de Negativa al Trabajo Inseguro",
+            "titulo": "Unsafe Work Refusal Policy",
             "file": "/docs/SSOMA-PO1 Política de negativa al trabajo inseguro-V2.pdf"
         },
         {
-            "titulo": "Política SIG",
+            "titulo": "SIG Policy",
             "file": "/docs/SIG-PO1 Política SIG -V2.pdf"
         },
         {
-            "titulo": "Política de Inclusión Laboral",
+            "titulo": "Labor Inclusion Policy",
             "file": "/docs/RRHH-PO1 Política de Inclusión Laboral-V2.pdf"
         },
         {
-            "titulo": "Política de Fatiga y Somnolencia",
+            "titulo": "Fatigue and Drowsiness Policy",
             "file": "/docs/SSOMA-PO2 Política de fatiga y somnolencia-V2-.pdf"
         },
         {
-            "titulo": "Alcance del Sistema Integrado de Gestión",
+            "titulo": "Scope of the Integrated Management System",
             "file": "/docs/SIG-FR1 Alcance del Sistema Integrado de Gestión v.02.pdf"
         }
     ]

--- a/public/locales/es/nosotros.json
+++ b/public/locales/es/nosotros.json
@@ -43,23 +43,23 @@
     "politicas_intro": "Accede a nuestras políticas que forman parte de nuestro Sistema Integrado de Gestión y que reflejan nuestro compromiso con la calidad, el cuidado del medio ambiente y la seguridad.",
     "politicas": [
         {
-            "titulo": "Unsafe Work Refusal Policy",
+            "titulo": "Política de Negativa al Trabajo Inseguro",
             "file": "/docs/SSOMA-PO1 Política de negativa al trabajo inseguro-V2.pdf"
         },
         {
-            "titulo": "SIG Policy",
+            "titulo": "Política SIG",
             "file": "/docs/SIG-PO1 Política SIG -V2.pdf"
         },
         {
-            "titulo": "Labor Inclusion Policy",
+            "titulo": "Política de Inclusión Laboral",
             "file": "/docs/RRHH-PO1 Política de Inclusión Laboral-V2.pdf"
         },
         {
-            "titulo": "Fatigue and Drowsiness Policy",
+            "titulo": "Política de Fatiga y Somnolencia",
             "file": "/docs/SSOMA-PO2 Política de fatiga y somnolencia-V2-.pdf"
         },
         {
-            "titulo": "Scope of the Integrated Management System",
+            "titulo": "Alcance del Sistema Integrado de Gestión",
             "file": "/docs/SIG-FR1 Alcance del Sistema Integrado de Gestión v.02.pdf"
         }
     ]


### PR DESCRIPTION
This pull request updates the English and Spanish localization files to ensure that policy titles are correctly translated and consistent across both languages. The changes improve clarity for users by providing accurate translations for the titles of key company policies.

Localization updates:

* In `public/locales/en/nosotros.json`, the policy titles are now in English, replacing the previous Spanish titles.
* In `public/locales/es/nosotros.json`, the policy titles are now in Spanish, correcting the previous English titles.