### PR TITLE
feat: last last last last last last

### DIFF
--- a/public/locales/en/inicio.json
+++ b/public/locales/en/inicio.json
@@ -12,7 +12,7 @@
         "separadores": "Concrete\nSpacers"
     },
     "servicios": {
-        "card1_titulo": "Comprehensive Management and Recycling of C&D Waste",
+        "card1_titulo": "C&D Waste Management & Recycling",
         "card1_desc": "We are an EO-RS authorized to collect, transport, dispose, and recycle C&D waste",
         "card2_titulo": "Industrial Waste Recycling",
         "card2_desc": "We develop custom projects for each client"

--- a/public/locales/en/servicios.json
+++ b/public/locales/en/servicios.json
@@ -1,7 +1,7 @@
 {
     "titulo": "Learn more about our services",
     "servicio1": {
-        "subtitulo": "Comprehensive Management and Recycling of C&D Waste",
+        "subtitulo": "C&D Waste Management & Recycling",
         "descripcion": "We are an EO-RS with official registration from MINAM to carry out the collection, transportation, and final disposal of C&D waste under the highest safety and quality standards. We stand out from other operators because we have a recycling plant where we process all recyclable material into new products. This way, our clients can mitigate the environmental impact of their projects."
     },
     "servicio2": {


### PR DESCRIPTION
This pull request makes minor updates to English localization strings to use more concise and standardized terminology for C&D (Construction and Demolition) waste management services.

- Localization improvements:
  * Updated the titles and subtitles for C&D waste management services to use "C&D Waste Management & Recycling" instead of the longer "Comprehensive Management and Recycling of C&D Waste" in both `inicio.json` and `servicios.json`. [[1]](diffhunk://#diff-70c73d6865b844904d91c88c9e84c516b0199d0cb1a9c079a6f77102c85c1324L15-R15) [[2]](diffhunk://#diff-355b60a4228079a56fd5f6687920794523ef7e7532693bc7946b587cdfe57f4aL4-R4)